### PR TITLE
chore: add release CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,3 @@
-# 整个流程的名字
 name: Release
 
 on:


### PR DESCRIPTION
增加自动发布协作流程CI

## 协作流程

- 仓库的贡献者，修改代码，执行 `pnpm run changeset` 生成 changeset 文件。
- maintainer 合并 PR 到 main 分支。
- 触发CI 生成 CHANGELOG 并创建一个 release PR。
- 新的携带 changeset 的修改会重新触发CI 更新 changelog。
- maintainer 在想发布新版本的时候 merge release PR 自动发布。